### PR TITLE
chore(deps): disable aws-lc-rs by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,6 +1029,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ rustls = ["rustls-webpki-roots"]
 rustls-http2 = ["http2", "rustls", "hyper-rustls/http2"]
 rustls-native-roots = ["__rustls", "hyper-rustls/rustls-native-certs"]
 rustls-webpki-roots = ["__rustls", "hyper-rustls/webpki-roots"]
+rustls-ring = ["__rustls", "hyper-rustls/ring"]
+rustls-aws-lc = ["__rustls", "hyper-rustls/aws-lc-rs"]
 
 __rustls = ["hyper-rustls"]
 
@@ -49,11 +51,16 @@ hyper = { version = "1.5.2", features = ["client"] }
 axum = { version = "0.8.1", features = [], optional = true }
 
 hyper-tls = { version = "0.6.0", optional = true }
-hyper-rustls = { version = "0.27.5", optional = true }
+hyper-rustls = { version = "0.27.5", optional = true, default-features = false, features = [
+    "http1",
+    "logging",
+    "native-tokio",
+    "tls12",
+] }
 
 regex = "1.8"
 log = "0.4.25"
-hyper-util = { version = "0.1.2", features = [
+hyper-util = { version = "0.1.10", features = [
     "client",
     "client-legacy",
     "tokio",

--- a/src/client.rs
+++ b/src/client.rs
@@ -92,9 +92,16 @@ where
     B::Data: Send,
 {
     let conn = hyper_rustls::HttpsConnectorBuilder::new();
-    #[cfg(feature = "rustls-webpki-roots")]
+    #[cfg(all(
+        any(feature = "rustls-ring", feature = "rustls-aws-lc"),
+        feature = "rustls-webpki-roots"
+    ))]
     let conn = conn.with_webpki_roots();
-    #[cfg(all(not(feature = "rustls-webpki-roots"), feature = "rustls-native-roots"))]
+    #[cfg(all(
+        not(feature = "rustls-webpki-roots"),
+        any(feature = "rustls-ring", feature = "rustls-aws-lc"),
+        feature = "rustls-native-roots"
+    ))]
     let conn = conn.with_native_roots();
     let conn = conn.https_only();
     #[cfg(feature = "http1")]


### PR DESCRIPTION
Not everyone uses aws-lc-rs with rustls. Allow
downstream consumers to choose instead of always
providing it.